### PR TITLE
added custom endpoint option and model select in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `servers` folder comprises of multiple variations of approaches towards a vo
 
 The numbered circles show the four stages of processing required to achieve the results and going through each of the process sequentially can cause alot of latency issues approx (~ 15-20 seconds avg). To adopt parallelism within these four processes, multiple experiments were conducted in terms of approaches which are listed below. Follow the steps below to run the application through these approaches
 
-- Create a .env file comprising of the folling details
+- Rename the file 'env.example' to '.env' and add your openai api key/
   ```
   OPENAI_API_KEY = "XXXXXXXXXXXXXX"
   ```
@@ -55,7 +55,7 @@ The numbered circles show the four stages of processing required to achieve the 
       ```
       npm run start:sse
       ```
-  - Run the server on `http://localhost:8000`
+  - Run the server on `http://localhost:3000`
 
 ### File Based Response Server
 The OpenAI API can create an audio buffer and also store the audio buffer into a file. The idea of this approach was to transfer the user's audio chunks in form data or a file. The transcribing step processes the file and converts it into a text and generates a streamed response through OpenAI. The chunk of stream are gathered in form of a sentence and sent to the `speak` method to be spoken out, the audio generated is saved in an audio file on the server which is played on the client as the audio data continue to stream in. The following diagram depicts the workflow

--- a/env.example
+++ b/env.example
@@ -1,0 +1,5 @@
+OPENAI_API_KEY = "XXXXXXXX"
+TEXT_RESPONSE_MODEL = "gpt-3.5-turbo"
+
+# Only change this if you're using a custom endpoint, otherwise leave as is.
+OPENAI_API_BASE = "https://api.openai.com/v1"

--- a/servers/events-based-server.js
+++ b/servers/events-based-server.js
@@ -12,6 +12,7 @@ const { Writable } = require('stream');
 
 const openai = new OpenAI({
   apiKey: `${process.env.OPENAI_API_KEY}`,
+  baseURL: `${process.env.OPENAI_API_BASE}`,
 });
 
 let app = express();
@@ -58,7 +59,7 @@ app.post("/upload-v2", upload.single("file"), async function (req, res) {
     console.log("Responding ....");
 
     const stream = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
       messages: [
         {
           role: "system",
@@ -201,14 +202,14 @@ app.post("/upload", upload.single("file"), async function (req, res) {
   if (req.body.lastChunk) {
     console.log("Responding ....");
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(`${process.env.OPENAI_API_BASE}/chat/completions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: "gpt-3.5-turbo",
+        model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
         messages: [
           {
             role: "user",
@@ -240,7 +241,7 @@ app.post("/respond", async function (req, res) {
   console.log(req.body.text);
 
   const stream = await openai.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
     messages: [{ role: "user", content: req.body.text }],
     stream: true,
   });

--- a/servers/file-based-response-server.js
+++ b/servers/file-based-response-server.js
@@ -10,6 +10,7 @@ require("dotenv").config();
 
 const openai = new OpenAI({
   apiKey: `${process.env.OPENAI_API_KEY}`,
+  baseURL: `${process.env.OPENAI_API_BASE}`,
 });
 
 var app = express();
@@ -51,14 +52,14 @@ app.post("/upload", upload.single("file"), async function (req, res) {
   if (req.body.lastChunk) {
     console.log("Responding ....");
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(`${process.env.OPENAI_API_BASE}/chat/completions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: "gpt-3.5-turbo",
+        model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
         messages: [
           {
             role: "user",
@@ -99,7 +100,7 @@ app.post("/upload-v2", upload.single("file"), async function (req, res) {
     console.log("Responding ....");
 
     const stream = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
       messages: [
         { role: "system", content: "you are a conversational chatbot, keep it short and keep it precise especially the first sentence. Respond in terms of paragraphs and use commas and full stop where necessary but keep the sentences short as much as possible, avoid bullet point in answers" },
         { role: "system", content: "keep your answers precise and short, make sure they are not greater than 50 words, in case of a longer answer, rephrase it and dont give away all the information instead question the user if they need more information" }, 
@@ -161,7 +162,7 @@ app.post("/respond", async function (req, res) {
   console.log(req.body.text);
 
   const stream = await openai.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
     messages: [{ role: "user", content: req.body.text }],
     stream: true,
   });

--- a/servers/sockets-server.js
+++ b/servers/sockets-server.js
@@ -11,6 +11,7 @@ require("dotenv").config();
 
 const openai = new OpenAI({
   apiKey: `${process.env.OPENAI_API_KEY}`,
+  baseURL: `${process.env.OPENAI_API_BASE}`,
 });
 
 const DONE = "[DONE]";
@@ -56,7 +57,7 @@ app.post("/upload-v2", upload.single("file"), async function (req, res) {
     console.log("Responding ....");
 
     const stream = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
       messages: [
         {
           role: "system",
@@ -134,14 +135,14 @@ app.post("/upload", upload.single("file"), async function (req, res) {
   if (req.body.lastChunk) {
     console.log("Responding ....");
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    const response = await fetch(`${process.env.OPENAI_API_BASE}/chat/completions`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
-        model: "gpt-3.5-turbo",
+        model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
         messages: [
           {
             role: "user",
@@ -173,7 +174,7 @@ app.post("/respond", async function (req, res) {
   console.log(req.body.text);
 
   const stream = await openai.chat.completions.create({
-    model: "gpt-3.5-turbo",
+    model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
     messages: [{ role: "user", content: req.body.text }],
     stream: true,
   });
@@ -223,7 +224,7 @@ async function generateResponse(transcribedData, socket) {
 
   if (transcribedData) {
     const stream = await openai.chat.completions.create({
-      model: "gpt-3.5-turbo",
+      model: process.env.TEXT_RESPONSE_MODEL || "gpt-3.5-turbo",
       messages: [
         {
           role: "system",


### PR DESCRIPTION
I updated the code to take a custom endpoint base URL for openai proxy's.

Changed the README.md to port 3000 instead of 8000.

Added a 'env.example' file.

Changed hard-coded text response model to .env variable.